### PR TITLE
Remove static linkage to libvulkan

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ stages:
       - checkout: self
         submodules: true
       - script: |
-          sudo apt-get update && sudo apt-get install -y libx11-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev mesa-common-dev libvulkan-dev
+          sudo apt-get update && sudo apt-get install -y libx11-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev mesa-common-dev
         displayName: 'Install dependencies'
       - script: |
           ./build_fonts.sh

--- a/build.gradle
+++ b/build.gradle
@@ -145,9 +145,6 @@ model {
                     if (!it.targetPlatform.operatingSystem.isWindows()) {
                         it.linker.args << '-fvisibility=hidden'
                     }
-                } else if (it.targetPlatform.operatingSystem.isLinux()) {
-                    it.cCompiler.define '_GLFW_VULKAN_STATIC'
-                    it.linker.args << '-lvulkan'
                 }
                 if (it.targetPlatform.operatingSystem.isWindows()) {
                     it.cCompiler.define '_GLFW_WIN32'


### PR DESCRIPTION
This avoids a runtime dependency on libvulkan-dev.