### PR TITLE
Set RPATH to $ORIGIN on unix platforms

### DIFF
--- a/config.gradle
+++ b/config.gradle
@@ -21,6 +21,14 @@ model {
     }
 }
 
+nativeUtils.platformConfigs.each {
+    if (it.name.contains('windows')) return
+    it.linker.args << '-Wl,-rpath,\'$ORIGIN\''
+    if (it.name == 'osxx86-64') {
+        it.linker.args << "-headerpad_max_install_names"
+    }
+}
+
 ext.appendDebugPathToBinaries = { binaries->
     binaries.withType(StaticLibraryBinarySpec) {
         if (it.buildType.name.contains('debug')) {


### PR DESCRIPTION
Will make tool loading much easier.

Also added headerpad_max_install_names to allow downstream consumers to change rpath as well on macos if necessary.