### PR TITLE
Build a single imgui library rather than combining 3 libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,8 +68,18 @@ model {
                         include '*.cpp', 'examples/imgui_impl_glfw.cpp', 'examples/imgui_impl_opengl3.cpp'
                     }
                     exportedHeaders {
-                        srcDirs 'imgui', 'fonts', 'stb', 'implot'
+                        srcDirs 'imgui', 'fonts', 'stb', 'implot', 'build/gl3w/include'
                         include '*.h', 'examples/imgui_impl_glfw.h', 'examples/imgui_impl_opengl3.h'
+                    }
+                }
+                c {
+                    source {
+                        srcDirs 'build/gl3w/src', 'glfw/src'
+                        include 'gl3w.c', 'context.c', 'init.c', 'input.c', 'monitor.c', 'vulkan.c', 'window.c', 'egl_context.c', 'osmesa_context.c'
+                    }
+                    exportedHeaders {
+                        srcDirs 'build/gl3w/include', 'glfw/include'
+                        include '*.h'
                     }
                 }
             }
@@ -79,7 +89,14 @@ model {
                 } else {
                     cppCompiler.args '-Wshadow', '-fexceptions', '-Wno-missing-field-initializers'
                 }
+                if (it in SharedLibraryBinarySpec) {
+                    it.cCompiler.define '_GLFW_BUILD_DLL'
+                    if (!it.targetPlatform.operatingSystem.isWindows()) {
+                        it.linker.args << '-fvisibility=hidden'
+                    }
+                }
                 if (it.targetPlatform.operatingSystem.isWindows()) {
+                    it.cCompiler.define '_GLFW_WIN32'
                     linker.args << 'kernel32.lib' << 'Gdi32.lib' << 'User32.lib' << 'Shell32.lib' << 'd3d11.lib' << 'd3dcompiler.lib'
                     it.sources {
                         imguiWindowsCpp(CppSourceSet) {
@@ -92,88 +109,6 @@ model {
                                 include '*.h', 'examples/imgui_impl_dx11.h'
                             }
                         }
-                    }
-                } else if (it.targetPlatform.operatingSystem.isMacOsX()) {
-                    it.linker.args << '-framework' << 'Metal' << '-framework' << 'MetalKit' << '-framework' << 'Cocoa' << '-framework' << 'IOKit' << '-framework' << 'CoreFoundation' << '-framework' << 'CoreVideo' << '-framework' << 'QuartzCore'
-                    it.sources {
-                        imguiMacObjectiveCpp(ObjectiveCppSourceSet) {
-                            source {
-                                srcDirs 'imgui'
-                                include 'examples/imgui_impl_metal.mm'
-                            }
-                            exportedHeaders {
-                                srcDirs 'imgui'
-                                include '*.h', 'examples/imgui_impl_metal.h'
-                            }
-                        }
-                    }
-                }
-                lib library: 'gl3w', linkage: 'static'
-                lib library: 'glfw3', linkage: 'static'
-            }
-            //binaries.withType(SharedLibraryBinarySpec) {
-            //    buildable = false
-            //}
-            appendDebugPathToBinaries(binaries)
-        }
-        gl3w(NativeLibrarySpec) {
-            sources {
-                c {
-                    source {
-                        srcDirs 'build/gl3w/src', 'gl3w-empty'
-                        include '*.c'
-                    }
-                    exportedHeaders {
-                        srcDirs 'build/gl3w/include'
-                        include '**/*.h'
-                    }
-                }
-            }
-            binaries.all {
-                if (toolChain in VisualCpp) {
-                    cCompiler.args '-D_UNICODE', '-DUNICODE', '-DWIN32', '-D_WIN32', '-DSTRICT', '-DWIN32_LEAN_AND_MEAN', '-D_HAS_EXCEPTIONS=1'
-                    linker.args << 'kernel32.lib' << 'Gdi32.lib'
-                } else {
-                    cCompiler.args '-Wshadow', '-fexceptions', '-Wno-missing-field-initializers'
-                }
-                if (it.targetPlatform.operatingSystem.isMacOsX()) {
-                    it.cCompiler.args << '-fno-common'
-                }
-            }
-            //binaries.withType(SharedLibraryBinarySpec) {
-            //    buildable = false
-            //}
-            appendDebugPathToBinaries(binaries)
-        }
-        glfw3(NativeLibrarySpec) {
-            sources {
-                c {
-                    source {
-                        srcDirs 'glfw/src'
-                        include 'context.c', 'init.c', 'input.c', 'monitor.c', 'vulkan.c', 'window.c', 'egl_context.c', 'osmesa_context.c'
-                    }
-                    exportedHeaders {
-                        srcDirs 'glfw/include'
-                        include '**/*.h'
-                    }
-                }
-            }
-            binaries.all {
-                if (toolChain in VisualCpp) {
-                    cCompiler.args '-D_UNICODE', '-DUNICODE', '-DWIN32', '-D_WIN32', '-DSTRICT', '-DWIN32_LEAN_AND_MEAN', '-D_HAS_EXCEPTIONS=1'
-                    linker.args << 'kernel32.lib' << 'Gdi32.lib' << 'User32.lib' << 'Shell32.lib'
-                } else {
-                    cCompiler.args '-Wshadow', '-fexceptions', '-Wno-missing-field-initializers'
-                }
-                if (it in SharedLibraryBinarySpec) {
-                    it.cCompiler.define '_GLFW_BUILD_DLL'
-                    if (!it.targetPlatform.operatingSystem.isWindows()) {
-                        it.linker.args << '-fvisibility=hidden'
-                    }
-                }
-                if (it.targetPlatform.operatingSystem.isWindows()) {
-                    it.cCompiler.define '_GLFW_WIN32'
-                    it.sources {
                         glfw3WindowsC(CSourceSet) {
                             source {
                                 srcDirs 'glfw/src'
@@ -193,8 +128,18 @@ model {
                     it.cCompiler.args << '-fno-common'
                     it.cCompiler.define '_GLFW_COCOA'
                     it.objcCompiler.define '_GLFW_COCOA'
-                    it.linker.args << '-framework' << 'Cocoa' << '-framework' << 'IOKit' << '-framework' << 'CoreFoundation' << '-framework' << 'CoreVideo'
+                    it.linker.args << '-framework' << 'Metal' << '-framework' << 'MetalKit' << '-framework' << 'Cocoa' << '-framework' << 'IOKit' << '-framework' << 'CoreFoundation' << '-framework' << 'CoreVideo' << '-framework' << 'QuartzCore'
                     it.sources {
+                        imguiMacObjectiveCpp(ObjectiveCppSourceSet) {
+                            source {
+                                srcDirs 'imgui'
+                                include 'examples/imgui_impl_metal.mm'
+                            }
+                            exportedHeaders {
+                                srcDirs 'imgui'
+                                include '*.h', 'examples/imgui_impl_metal.h'
+                            }
+                        }
                         glfw3MacC(CSourceSet) {
                             source {
                                 srcDirs 'glfw/src'

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ model {
                         include '*.cpp', 'examples/imgui_impl_glfw.cpp', 'examples/imgui_impl_opengl3.cpp'
                     }
                     exportedHeaders {
-                        srcDirs 'imgui', 'fonts', 'stb', 'implot', 'build/gl3w/include'
+                        srcDirs 'imgui', 'fonts', 'stb', 'implot', 'build/gl3w/include', 'glfw/include'
                         include '*.h', 'examples/imgui_impl_glfw.h', 'examples/imgui_impl_opengl3.h'
                     }
                 }

--- a/config.gradle
+++ b/config.gradle
@@ -77,7 +77,6 @@ ext.createComponentZipTasks = { components, names, base, type, project, func ->
     components.each {
         if (it in NativeLibrarySpec && stringNames.contains(it.name)) {
             it.binaries.each {
-                if (it instanceof StaticLibraryBinarySpec) return
                 if (!it.buildable) return
                 def target = nativeUtils.getPublishClassifier(it)
                 if (configMap.containsKey(target)) {

--- a/publish.gradle
+++ b/publish.gradle
@@ -14,7 +14,7 @@ publishing {
     }
 }
 
-def releaseNumber = 7
+def releaseNumber = 8
 
 def pubVersion = "1.76-$releaseNumber"
 
@@ -135,193 +135,13 @@ build.dependsOn cppSourcesZip
 addTaskToCopyAllOutputs(cppHeadersZip)
 addTaskToCopyAllOutputs(cppSourcesZip)
 
-class CombineTask extends DefaultTask {
-    @OutputDirectory
-    File outputDirectory
-
-    @OutputFile
-    File outputFile
-
-    @Internal
-    StaticLibraryBinarySpec binSpec
-}
-
 model {
     publishing {
-        def tpMap = [:]
-        $.binaries.each {
-            def key = '';
-            if (it instanceof StaticLibraryBinarySpec) {
-                key = "$it.targetPlatform.name:$it.buildType.name".toString()
-            } else {
-                return
-            }
-            def value = tpMap[key]
-            if (value == null) {
-                value = []
-                tpMap.put(key, value)
-            }
-            value << it
-        }
-
-        def combineZipTasks = []
-
-        def root = project.file('build/combined')
-        tpMap.each { bins ->
-            def folderName = bins.key.replace(':', '')
-            def combineTask = project.tasks.create("combine${folderName}combinedlibrary", CombineTask) { t ->
-                build.dependsOn t
-                def files = []
-
-                def targetPlatform
-                def toolChain
-                def buildType
-
-                bins.value.each { binary->
-                    t.dependsOn binary.tasks.createStaticLib
-                    inputs.file(binary.staticLibraryFile)
-                    files << binary.staticLibraryFile
-                    targetPlatform = binary.targetPlatform
-                    toolChain = binary.toolChain
-                    buildType = binary.buildType
-                    binSpec = binary
-                }
-
-                inputs.files(files)
-
-                def outputDir = new File(root, folderName)
-
-                outputDirectory = outputDir
-
-                def debugStr =  buildType.name.contains('debug') ? 'd' : ''
-
-                if (targetPlatform.operatingSystem.isWindows()) {
-                    outputFile = project.file("$outputDir\\imgui${debugStr}.lib")
-                } else {
-                    outputFile = project.file("$outputDir\\libimgui${debugStr}.a")
-                }
-
-                outputs.file(outputFile)
-
-                def pdbFiles = []
-
-                def sourceLinkFile
-
-                if (targetPlatform.operatingSystem.isWindows()) {
-                    sourceLinkFile = tasks.named('generateSourceLinkFile')
-                    dependsOn sourceLinkFile
-                }
-
-                doFirst {
-                    files.each {
-                        project.fileTree(it.parentFile.absolutePath).matching {
-                            include "*.pdb"
-                        }.each {
-                            pdbFiles << it
-                        }
-                    }
-                }
-
-                doLast {
-
-                    if (targetPlatform.operatingSystem.isWindows()) {
-                        // Find Windows Toolchain
-                        def vslocator = project.services.get(VisualStudioLocator.class)
-                        def vsiSearch = vslocator.locateComponent(toolChain.installDir)
-                        if (vsiSearch.available) {
-                            def vsi = vsiSearch.component
-                            def vscpp = vsi.visualCpp.forPlatform(targetPlatform)
-                            def libExe = vscpp.archiverExecutable
-
-                            def runargs = ["/OUT:${outputFile.toString()}".toString()]
-                            files.each {
-                                runargs << it.toString()
-                            }
-
-                            outputDir.mkdirs()
-
-                            project.exec {
-                                executable libExe
-                                args(runargs)
-                            }
-                            project.copy {
-                                from pdbFiles
-                                into outputDir
-                            }
-                            project.copy {
-                                from sourceLinkFile.get().sourceLinkBaseFile
-                                into outputDir
-                            }
-
-                        } else {
-                            throw new GradleException("Could not combine windows archive")
-                        }
-                    } else if (targetPlatform.operatingSystem.isMacOsX()) {
-                        def setArgs = ['-static', '-o', "libimgui${debugStr}.a".toString()]
-
-                        files.each {
-                            setArgs << it.absolutePath
-                        }
-
-                        project.exec {
-                            executable 'libtool'
-                            workingDir outputDir
-                            args = setArgs
-                        }
-                    } else {
-                        def inputString = "create libimgui${debugStr}.a\n".toString()
-                        files.each {
-                            def inFile = 'addlib ' + it + '\n'
-                            inputString += inFile
-                        }
-                        inputString += 'save\nend\n'
-                        project.exec {
-                            executable 'ar'
-                            workingDir outputDir
-                            args = ['-M']
-                            standardInput = new ByteArrayInputStream(inputString.bytes)
-                        }
-                    }
-                }
-            }
-
-            def clsfier = nativeUtils.getPublishClassifier(combineTask.binSpec)
-
-            def combineZipTask =  project.tasks.create(zipBaseName + '-' + clsfier, Zip) {
-                description = 'Create component archive for static ' + clsfier
-                destinationDirectory = outputsFolder
-                classifier = clsfier
-                archiveBaseName = '_M_' + zipBaseName
-                duplicatesStrategy = 'exclude'
-
-                from (licenseFile) {
-                    into '/'
-                }
-
-                dependsOn combineTask
-
-                from(combineTask.outputDirectory) {
-                    into nativeUtils.getPlatformPath(combineTask.binSpec) + '/static'
-                }
-            }
-
-            combineZipTasks << combineZipTask
-
-            project.build.dependsOn combineZipTask
-            project.artifacts {
-                combineZipTask
-            }
-            addTaskToCopyAllOutputs(combineZipTask)
-        }
-
         def gTaskList = createComponentZipTasks($.components, ['imgui'], zipBaseName, Zip, project, includeStandardZipFormat)
 
         publications {
             cpp(MavenPublication) {
                 gTaskList.each {
-                    artifact it
-                }
-                combineZipTasks.each {
                     artifact it
                 }
                 artifact cppHeadersZip


### PR DESCRIPTION
This fixes symbol exports on Windows shared libraries.

- [x] Build/publish static libs as well as shared