### PR TITLE
Disable shared library builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -184,9 +184,9 @@ model {
                     }
                 }
             }
-            //binaries.withType(SharedLibraryBinarySpec) {
-            //    buildable = false
-            //}
+            binaries.withType(SharedLibraryBinarySpec) {
+                buildable = false
+            }
             appendDebugPathToBinaries(binaries)
         }
     }

--- a/config.gradle
+++ b/config.gradle
@@ -77,6 +77,7 @@ ext.createComponentZipTasks = { components, names, base, type, project, func ->
     components.each {
         if (it in NativeLibrarySpec && stringNames.contains(it.name)) {
             it.binaries.each {
+                if (it instanceof SharedLibraryBinarySpec) return
                 if (!it.buildable) return
                 def target = nativeUtils.getPublishClassifier(it)
                 if (configMap.containsKey(target)) {

--- a/publish.gradle
+++ b/publish.gradle
@@ -14,7 +14,7 @@ publishing {
     }
 }
 
-def releaseNumber = 8
+def releaseNumber = 9
 
 def pubVersion = "1.76-$releaseNumber"
 


### PR DESCRIPTION
They don't properly export symbols on Windows, and we will likely never
need them.